### PR TITLE
[feat.] 添加安装系统自带ROS的功能

### DIFF
--- a/install.py
+++ b/install.py
@@ -33,6 +33,7 @@ tools ={
     13: {'tip':'一键配置:python国内源','type':CONFIG_TOOL,'tool':url_prefix+'tools/tool_config_python_source.py' ,'dep':[] },
     14: {'tip':'一键安装:科学上网代理工具','type':INSTALL_SOFTWARE,'tool':url_prefix+'tools/tool_install_proxy_tool.py' ,'dep':[8] },
     15: {'tip':'一键安装：QQ for Linux', 'type':INSTALL_SOFTWARE, 'tool': url_prefix+'tools/tool_install_qq.py', 'dep':[]},
+    16: {'tip':'一键安装：系统自带ROS (22.04 及以上原生)'type':INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
     # 77: {'tip':'测试模式:运行自定义工具测试'},
     }
 # 

--- a/install.py
+++ b/install.py
@@ -33,7 +33,7 @@ tools ={
     13: {'tip':'一键配置:python国内源','type':CONFIG_TOOL,'tool':url_prefix+'tools/tool_config_python_source.py' ,'dep':[] },
     14: {'tip':'一键安装:科学上网代理工具','type':INSTALL_SOFTWARE,'tool':url_prefix+'tools/tool_install_proxy_tool.py' ,'dep':[8] },
     15: {'tip':'一键安装：QQ for Linux', 'type':INSTALL_SOFTWARE, 'tool': url_prefix+'tools/tool_install_qq.py', 'dep':[]},
-    16: {'tip':'一键安装：系统自带ROS (22.04 及以上原生)', type:INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
+    16: {'tip':'一键安装：系统自带ROS (22.04 及以上原生)', 'type':INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
     # 77: {'tip':'测试模式:运行自定义工具测试'},
     }
 # 

--- a/install.py
+++ b/install.py
@@ -33,7 +33,7 @@ tools ={
     13: {'tip':'一键配置:python国内源','type':CONFIG_TOOL,'tool':url_prefix+'tools/tool_config_python_source.py' ,'dep':[] },
     14: {'tip':'一键安装:科学上网代理工具','type':INSTALL_SOFTWARE,'tool':url_prefix+'tools/tool_install_proxy_tool.py' ,'dep':[8] },
     15: {'tip':'一键安装：QQ for Linux', 'type':INSTALL_SOFTWARE, 'tool': url_prefix+'tools/tool_install_qq.py', 'dep':[]},
-    16: {'tip':'一键安装：系统自带ROS (22.04 及以上原生)'type':INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
+    16: {'tip':'一键安装：系统自带ROS (22.04 及以上原生)', type:INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
     # 77: {'tip':'测试模式:运行自定义工具测试'},
     }
 # 

--- a/install.py
+++ b/install.py
@@ -33,7 +33,7 @@ tools ={
     13: {'tip':'一键配置:python国内源','type':CONFIG_TOOL,'tool':url_prefix+'tools/tool_config_python_source.py' ,'dep':[] },
     14: {'tip':'一键安装:科学上网代理工具','type':INSTALL_SOFTWARE,'tool':url_prefix+'tools/tool_install_proxy_tool.py' ,'dep':[8] },
     15: {'tip':'一键安装：QQ for Linux', 'type':INSTALL_SOFTWARE, 'tool': url_prefix+'tools/tool_install_qq.py', 'dep':[]},
-    16: {'tip':'一键安装：系统自带ROS (慎用！除非你知道这是什么)', 'type':INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
+    16: {'tip':'一键安装：系统自带ROS (！！警告！！仅供特殊情况下使用)', 'type':INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
     # 77: {'tip':'测试模式:运行自定义工具测试'},
     }
 # 

--- a/install.py
+++ b/install.py
@@ -33,7 +33,7 @@ tools ={
     13: {'tip':'一键配置:python国内源','type':CONFIG_TOOL,'tool':url_prefix+'tools/tool_config_python_source.py' ,'dep':[] },
     14: {'tip':'一键安装:科学上网代理工具','type':INSTALL_SOFTWARE,'tool':url_prefix+'tools/tool_install_proxy_tool.py' ,'dep':[8] },
     15: {'tip':'一键安装：QQ for Linux', 'type':INSTALL_SOFTWARE, 'tool': url_prefix+'tools/tool_install_qq.py', 'dep':[]},
-    16: {'tip':'一键安装：系统自带ROS (22.04 及以上原生)', 'type':INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
+    16: {'tip':'一键安装：系统自带ROS (慎用！除非你知道这是什么)', 'type':INSTALL_ROS, 'tool': url_prefix+'tools/tool_install_ros1_systemdefault.py', 'dep':[5]},
     # 77: {'tip':'测试模式:运行自定义工具测试'},
     }
 # 

--- a/tools/tool_install_ros1_systemdefault.py
+++ b/tools/tool_install_ros1_systemdefault.py
@@ -26,9 +26,6 @@ class Tool(BaseTool):
             tool.change_sys_source()
 
     def install_system_ros(self):
-        dic_base = AptUtils.search_package('ros-base','ros-[A-Za-z]+-ros-base',"ros-","-base")
-        if dic_base== None: return False
-
         version_dic = {1:"完整版",2:"基础版(小)"}
         code,name = ChooseTask(version_dic,"请选择安装的具体版本(如果不知道怎么选,请选1桌面版):",False).run()
 

--- a/tools/tool_install_ros1_systemdefault.py
+++ b/tools/tool_install_ros1_systemdefault.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+from .base import BaseTool
+from .base import PrintUtils,CmdTask,FileUtils,AptUtils,ChooseTask
+from .base import osversion
+from .base import run_tool_file
+
+class Tool(BaseTool):
+    def __init__(self):
+        self.type = BaseTool.TYPE_INSTALL
+        self.name = "一键安装系统自带ROS，仅在Ubuntu 22.04 及以上版本系统中使用。"
+        self.autor = 'Elysia'
+
+    def run(self):
+        #正式的运行
+        self.check_sys_source()
+        self.install_system_ros()
+        return True
+
+    def check_sys_source(self):
+        # 更换系统源
+        dic = {1:"更换系统源再继续安装",2:"不更换继续安装"}
+        PrintUtils.print_warn("=========接下来这一步很很很很重要，如果不知道怎么选请选择1========")
+        code,result = ChooseTask(dic, "新手或首次安装一定要一定要一定要换源并清理三方源，换源!!!系统默认国外源容易失败!!").run()
+        if code==1: 
+            tool = run_tool_file('tools.tool_config_system_source',autorun=False)
+            tool.change_sys_source()
+
+    def install_system_ros():
+        dic_base = AptUtils.search_package('ros-base','ros-[A-Za-z]+-ros-base',"ros-","-base")
+        if dic_base== None: return False
+
+        version_dic = {1:"完整版",2:"基础版(小)"}
+        code,name = ChooseTask(version_dic,"请选择安装的具体版本(如果不知道怎么选,请选1桌面版):",False).run()
+
+        if code==0: 
+            print("你选择退出。。。。")
+            return
+
+        install_tool = 'aptitude'
+        install_tool_apt = 'apt'
+        if osversion.get_version() == "16.04":
+            install_tool = 'apt'
+
+        if install_tool=='aptitude':
+            AptUtils.install_pkg('aptitude')
+            AptUtils.install_pkg('aptitude')
+
+        # 先尝试使用apt 安装，之后再使用aptitude。
+        if code==2:
+            # 第一次尝试
+            cmd_result = CmdTask("sudo {} install  {} -y".format(install_tool_apt,"ros-base-dev"),300,os_command=True).run()
+            cmd_result = CmdTask("sudo {} install  {} -y".format(install_tool_apt,"ros-base-dev"),300,os_command=False).run()
+            if FileUtils.check_result(cmd_result,['未满足的依赖关系','unmet dependencies','but it is not installable']):
+                # 尝试使用aptitude解决依赖问题
+                PrintUtils.print_warn("============================================================")
+                PrintUtils.print_delay("请注意我，检测你在安装过程中出现依赖问题，请在稍后输入n,再选择y,即可解决")
+                import time
+                input("确认了解情况，请输入回车继续安装")
+                cmd_result = CmdTask("sudo {} install   {} ".format(install_tool,"ros-base-dev"),300,os_command=True).run()
+                cmd_result = CmdTask("sudo {} install   {} -y".format(install_tool,"ros-base-dev"),300,os_command=False).run()
+        
+        elif code==1:
+            cmd_result = CmdTask("sudo {} install   {} -y".format(install_tool_apt,"ros-desktop-full-dev"),300,os_command=True).run()
+            cmd_result = CmdTask("sudo {} install   {} -y".format(install_tool_apt,"ros-desktop-full-dev"),300,os_command=False).run()
+            if FileUtils.check_result(cmd_result,['未满足的依赖关系','unmet dependencies','but it is not installable']):
+                # 尝试使用aptitude解决依赖问题
+                PrintUtils.print_warn("============================================================")
+                PrintUtils.print_delay("请注意我，检测你在安装过程中出现依赖问题，请在稍后输入n,再选择y,即可解决（若无法解决，清在稍后手动运行命令: sudo aptitude install {})".format(RosVersions.get_desktop_version(install_version)))
+                import time
+                input("确认了解情况，请输入回车继续安装")
+                cmd_result = CmdTask("sudo {} install   {}".format(install_tool,"ros-desktop-full-dev"),300,os_command=True).run()
+                cmd_result = CmdTask("sudo {} install   {} -y".format(install_tool,"ros-desktop-full-dev"),300,os_command=False).run()
+
+        # apt broken error
+        if cmd_result[0]!=0:
+            if FileUtils.check_result(cmd_result[1]+cmd_result[2],['sudo apt --fix-broken install -y']):
+                if code==2: cmd_result = CmdTask("sudo {} install   {} -y".format(install_tool,"ros-base-dev"),300,os_command=False).run()
+                elif code==1: cmd_result = CmdTask("sudo {} install   {} -y".format(install_tool,"ros-desktop-full-dev"),300,os_command=False).run()
+
+        return True

--- a/tools/tool_install_ros1_systemdefault.py
+++ b/tools/tool_install_ros1_systemdefault.py
@@ -9,6 +9,7 @@ class Tool(BaseTool):
         self.type = BaseTool.TYPE_INSTALL
         self.name = "一键安装系统自带ROS，仅在Ubuntu 22.04 及以上版本系统中使用。"
         self.autor = 'Elysia'
+        PrintUtils.print_warn("警告！！此工具安装的ROS与从ROS官方软件源安装的ROS冲突！")
 
     def run(self):
         #正式的运行
@@ -50,7 +51,7 @@ class Tool(BaseTool):
             if FileUtils.check_result(cmd_result,['未满足的依赖关系','unmet dependencies','but it is not installable']):
                 # 尝试使用aptitude解决依赖问题
                 PrintUtils.print_warn("============================================================")
-                PrintUtils.print_delay("请注意我，检测你在安装过程中出现依赖问题，请在稍后输入n,再选择y,即可解决")
+                PrintUtils.print_delay("请注意，检测你在安装过程中出现依赖问题，请在稍后输入n,再选择y,即可解决")
                 import time
                 input("确认了解情况，请输入回车继续安装")
                 cmd_result = CmdTask("sudo {} install   {} ".format(install_tool,"ros-base-dev"),300,os_command=True).run()
@@ -62,7 +63,7 @@ class Tool(BaseTool):
             if FileUtils.check_result(cmd_result,['未满足的依赖关系','unmet dependencies','but it is not installable']):
                 # 尝试使用aptitude解决依赖问题
                 PrintUtils.print_warn("============================================================")
-                PrintUtils.print_delay("请注意我，检测你在安装过程中出现依赖问题，请在稍后输入n,再选择y,即可解决（若无法解决，清在稍后手动运行命令: sudo aptitude install {})".format(RosVersions.get_desktop_version(install_version)))
+                PrintUtils.print_delay("请注意，检测你在安装过程中出现依赖问题，请在稍后输入n,再选择y,即可解决（若无法解决，清在稍后手动运行命令: sudo aptitude install {})".format(RosVersions.get_desktop_version(install_version)))
                 import time
                 input("确认了解情况，请输入回车继续安装")
                 cmd_result = CmdTask("sudo {} install   {}".format(install_tool,"ros-desktop-full-dev"),300,os_command=True).run()

--- a/tools/tool_install_ros1_systemdefault.py
+++ b/tools/tool_install_ros1_systemdefault.py
@@ -25,7 +25,7 @@ class Tool(BaseTool):
             tool = run_tool_file('tools.tool_config_system_source',autorun=False)
             tool.change_sys_source()
 
-    def install_system_ros():
+    def install_system_ros(self):
         dic_base = AptUtils.search_package('ros-base','ros-[A-Za-z]+-ros-base',"ros-","-base")
         if dic_base== None: return False
 


### PR DESCRIPTION
如题，此pr将为自动安装程序添加使用系统ROS的功能。

由于ROS官方不再为ROS1 发布新系统的更新，在新的操作系统上使用ROS变得十分困难。即使可以通过Docker等虚拟化的方式实现曲线救国式的安装，但使用起来仍旧复杂。

本pr提供了使用系统ROS的可能，通过安装系统的ROS软件包后，即使在Ubuntu 22.04 上依然能够正常使用roocore等命令,详细情况见下图：

![image](https://github.com/fishros/install/assets/39023210/5e4ffc52-0b57-4c36-8159-6044f1a11440)

需要注意的是，这个方式安装的ROS仅含有基本组件。可以理解为ROS的最小系统版本。比如，这个版本里面没有维护如rqt等等软件包，

同时，此方法安装的ROS并**不能**与使用ROS官方软件源安装的ROS/ROS2共存！

介于以上情况，此方法安装的ROS仅供特殊人员在特殊情况下使用，在安装目录处做了警示说明。