### PR TITLE
添加docker安装jazzy源。并且在安装ROS版本列表中显示是ROS1还是ROS2

### DIFF
--- a/tools/tool_install_ros_with_docker.py
+++ b/tools/tool_install_ros_with_docker.py
@@ -16,7 +16,8 @@ class RosVersion:
 
 
 class RosVersions:
-    ros_version = [
+    ros_version = [ 
+        RosVersion('jazzy', 'ROS2', RosVersion.STATUS_LTS, ['osrf/ros:jazzy-desktop-full'],["ros:jazzy"]),
         RosVersion('noetic',  'ROS1', RosVersion.STATUS_LTS, ['fishros2/ros:noetic-desktop-full'],["ros:noetic"]),
         RosVersion('humble',  'ROS2', RosVersion.STATUS_LTS, ['fishros2/ros:humble-desktop-full'],["ros:humble"]),
         RosVersion('foxy',  'ROS2', RosVersion.STATUS_LTS, ['fishros2/ros:foxy-desktop'],["ros:foxy"]),
@@ -78,7 +79,7 @@ class RosVersions:
         """获取可安装的ROS版本列表"""
         names = []
         for version in RosVersions.ros_version:
-            names.append(version.name)
+            names.append(f'{version.name}    {version.version}')
         return names
 
 


### PR DESCRIPTION
使用docker安装ROS时，只有ROS版本名称，没有显示是ROS1 还是ROS2。
本次提交添加了显示ROS 的信息。
另外添加最新jazzy的docker安装。