### PR TITLE
fix(docs): 更改一键安装指令使其适配zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 使用方法
 ```
-wget http://fishros.com/install -O fishros && . fishros
+wget http://fishros.com/install -O fishros && chmod +x fishros && ./fishros
 ```
 
 ## 如何自动选择(Dockerfile中使用)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 使用方法
 ```
-wget http://fishros.com/install -O fishros && chmod +x fishros && ./fishros
+wget http://fishros.com/install -O fishros && source ./fishros
 ```
 
 ## 如何自动选择(Dockerfile中使用)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ## 使用方法
 ```
-wget http://fishros.com/install -O fishros && source ./fishros
+source <(wget -qO- http://fishros.com/install)
 ```
 
 ## 如何自动选择(Dockerfile中使用)


### PR DESCRIPTION
如题 `./xxx.sh` 的方式在zsh和bash中都支持，改为这个方式是个更兼容的方案。